### PR TITLE
Update Patient and Practitioner Resources

### DIFF
--- a/fhirResourcesToLoad/1. practitioner.json
+++ b/fhirResourcesToLoad/1. practitioner.json
@@ -7,16 +7,28 @@
       "value": "1122334455"
     }
   ],
+  "address": [
+    {
+      "use": "home",
+      "type": "both",
+      "state": "NY",
+      "city": "Buffalo",
+      "postalCode": "14210",
+      "line": ["840 Seneca St"]
+    }
+  ],
+  "telecom": [
+    {
+      "system": "phone",
+      "value": "716-873-1557"
+    }
+  ],
   "name": [
     {
       "use": "official",
       "family": "Doe",
-      "given": [
-        "Jane", "Betty"
-      ],
-      "prefix": [
-        "Dr."
-      ]
+      "given": ["Jane", "Betty"],
+      "prefix": ["Dr."]
     }
   ]
 }

--- a/fhirResourcesToLoad/3. patient.json
+++ b/fhirResourcesToLoad/3. patient.json
@@ -7,18 +7,23 @@
     {
       "use": "home",
       "type": "both",
-      "state": "MA"
+      "state": "MA",
+      "city": "Somerville",
+      "postalCode": "02143",
+      "line": ["14 Tyler St"]
     }
   ],
   "name": [
     {
       "use": "official",
       "family": "Tables",
-      "given": [
-        "Bobby",
-        "D",
-        "Tables"
-      ]
+      "given": ["Bobby", "D", "Tables"]
+    }
+  ],
+  "identifier": [
+    {
+      "system": "http://hl7.org/fhir/sid/us-medicare",
+      "value": "45678900001JS"
     }
   ]
 }

--- a/fhirResourcesToLoad/o2billy_01__patient.json
+++ b/fhirResourcesToLoad/o2billy_01__patient.json
@@ -7,18 +7,23 @@
     {
       "use": "home",
       "type": "both",
-      "state": "MA"
+      "state": "MA",
+      "city": "Bedford",
+      "postalCode": "01730",
+      "line": ["202 Burlington Road"]
     }
   ],
   "name": [
     {
       "use": "official",
       "family": "Oster",
-      "given": [
-        "William",
-        "Hale",
-        "Oster"
-      ]
+      "given": ["William", "Hale", "Oster"]
+    }
+  ],
+  "identifier": [
+    {
+      "system": "http://hl7.org/fhir/sid/us-medicare",
+      "value": "3435500006FW"
     }
   ]
 }

--- a/fhirResourcesToLoad/o2jane_01__patient.json
+++ b/fhirResourcesToLoad/o2jane_01__patient.json
@@ -7,18 +7,23 @@
     {
       "use": "home",
       "type": "both",
-      "state": "VT"
+      "state": "NY",
+      "city": "Buffalo",
+      "postalCode": "14203",
+      "line": ["55 E Huron Street"]
     }
   ],
   "name": [
     {
       "use": "official",
       "family": "Wilson",
-      "given": [
-        "Ada",
-        "Lovelace",
-        "Wilson"
-      ]
+      "given": ["Ada", "Lovelace", "Wilson"]
+    }
+  ],
+  "identifier": [
+    {
+      "system": "http://hl7.org/fhir/sid/us-medicare",
+      "value": "98127643501AA"
     }
   ]
 }

--- a/fhirResourcesToLoad/o2john_01__patient.json
+++ b/fhirResourcesToLoad/o2john_01__patient.json
@@ -7,18 +7,17 @@
     {
       "use": "home",
       "type": "both",
-      "state": "NY"
+      "state": "VA",
+      "city": "Reston",
+      "postalCode": "20190",
+      "line": ["11951 Freedom Drive Suite 1322"]
     }
   ],
   "name": [
     {
       "use": "official",
       "family": "Quinton",
-      "given": [
-        "Vlad",
-        "Alan",
-        "Nestor"
-      ]
+      "given": ["Vlad", "Alan", "Nestor"]
     }
   ],
   "identifier": [

--- a/fhirResourcesToLoad/o2teddy_01__patient.json
+++ b/fhirResourcesToLoad/o2teddy_01__patient.json
@@ -7,18 +7,23 @@
     {
       "use": "home",
       "type": "both",
-      "state": "VA"
+      "state": "VA",
+      "city": "McLean",
+      "postalCode": "22102",
+      "line": ["7525 Colshire Dr"]
     }
   ],
   "name": [
     {
       "use": "official",
       "family": "Roosevelt",
-      "given": [
-        "Theodor",
-        "Alan",
-        "Roosevelt"
-      ]
+      "given": ["Theodor", "Alan", "Roosevelt"]
+    }
+  ],
+  "identifier": [
+    {
+      "system": "http://hl7.org/fhir/sid/us-medicare",
+      "value": "84612900001NF"
     }
   ]
 }

--- a/fhirResourcesToLoad/o2teddy_04__practitioner.json
+++ b/fhirResourcesToLoad/o2teddy_04__practitioner.json
@@ -7,15 +7,27 @@
       "value": "348074389"
     }
   ],
+  "address": [
+    {
+      "use": "home",
+      "type": "both",
+      "state": "MA",
+      "city": "Burlington",
+      "postalCode": "01803",
+      "line": ["108 Middlesex Turnpike"]
+    }
+  ],
+  "telecom": [
+    {
+      "system": "phone",
+      "value": "781-229-3911"
+    }
+  ],
   "name": [
     {
       "family": "Smythe",
-      "given": [
-        "Juliette"
-      ],
-      "prefix": [
-        "Dr."
-      ]
+      "given": ["Juliette"],
+      "prefix": ["Dr."]
     }
   ]
 }


### PR DESCRIPTION
To ensure the PAS Claim Bundle sent by DTR includes all of the required information for the X12 transaction there are a few details which had to be added to the Patient and Practitioner resources in the ehr.