### PR TITLE
[697] Migrate Home Oxygen STU3 HIMSS 2020 Changes to R4

### DIFF
--- a/fhirResourcesToLoad/o2billy_03__observation_oxygen_pao2.json
+++ b/fhirResourcesToLoad/o2billy_03__observation_oxygen_pao2.json
@@ -1,25 +1,25 @@
 {
   "resourceType": "Observation",
-  "id": "obs015B",
-  "status": "final",
+  "id": "obs-pat015-pao2",
   "category": [
     {
       "coding": [
         {
-          "system": "http://hl7.org/fhir/observation-category",
+          "system": "http://terminology.hl7.org/CodeSystem/observation-category",
           "code": "laboratory",
-          "display": "laboratory"
+          "display": "Laboratory"
         }
       ],
       "text": "Laboratory"
     }
   ],
+  "status": "final",
   "code": {
     "coding": [
       {
         "system": "http://loinc.org",
-        "code": "31100-1",
-        "display": "Hematocrit [Volume Fraction] of Blood by Impedance"
+        "code": "2703-7",
+        "display": "Oxygen (BldA) [Partial pressure]"
       }
     ]
   },
@@ -28,35 +28,36 @@
   },
   "issued": "2020-03-20T15:30:10+01:00",
   "valueQuantity": {
-    "value": 69,
-    "unit": "%",
+    "value": 65,
+    "unit": "mm[Hg]",
     "system": "http://unitsofmeasure.org",
-    "code": "%"
+    "code": "mm[Hg]"
   },
   "interpretation": [
     {
       "coding": [
         {
           "system": "http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation",
-          "code": "H",
-          "display": "High"
+          "code": "L",
+          "display": "LOW"
         }
-      ]
+      ],
+      "text": "Normal (applies to non-numeric results)"
     }
   ],
   "referenceRange": [
     {
       "low": {
-        "value": 42,
-        "unit": "%",
+        "value": 75,
+        "unit": "mm[Hg]",
         "system": "http://unitsofmeasure.org",
-        "code": "%"
+        "code": "mm[Hg]"
       },
       "high": {
-        "value": 54,
-        "unit": "%",
+        "value": 100,
+        "unit": "mm[Hg]",
         "system": "http://unitsofmeasure.org",
-        "code": "%"
+        "code": "mm[Hg]"
       }
     }
   ]

--- a/fhirResourcesToLoad/o2billy_03__observation_oxygenexercise.json
+++ b/fhirResourcesToLoad/o2billy_03__observation_oxygenexercise.json
@@ -1,25 +1,25 @@
 {
   "resourceType": "Observation",
-  "id": "obs015B",
-  "status": "final",
+  "id": "obs-pat015-o2excercise",
   "category": [
     {
       "coding": [
         {
-          "system": "http://hl7.org/fhir/observation-category",
-          "code": "laboratory",
-          "display": "laboratory"
+          "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+          "code": "vital-signs",
+          "display": "Vital Signs"
         }
       ],
-      "text": "Laboratory"
+      "text": "Vital Signs"
     }
   ],
+  "status": "final",
   "code": {
     "coding": [
       {
         "system": "http://loinc.org",
-        "code": "31100-1",
-        "display": "Hematocrit [Volume Fraction] of Blood by Impedance"
+        "code": "89276-0",
+        "display": "Oxygen saturation with exercise"
       }
     ]
   },
@@ -28,7 +28,7 @@
   },
   "issued": "2020-03-20T15:30:10+01:00",
   "valueQuantity": {
-    "value": 69,
+    "value": 80,
     "unit": "%",
     "system": "http://unitsofmeasure.org",
     "code": "%"
@@ -38,26 +38,27 @@
       "coding": [
         {
           "system": "http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation",
-          "code": "H",
-          "display": "High"
+          "code": "L",
+          "display": "LOW"
         }
-      ]
+      ],
+      "text": "Normal (applies to non-numeric results)"
     }
   ],
   "referenceRange": [
     {
       "low": {
-        "value": 42,
+        "value": 90,
         "unit": "%",
         "system": "http://unitsofmeasure.org",
         "code": "%"
       },
       "high": {
-        "value": 54,
+        "value": 99,
         "unit": "%",
         "system": "http://unitsofmeasure.org",
         "code": "%"
       }
     }
   ]
-}
+} 

--- a/fhirResourcesToLoad/o2billy_03__observation_oxygensaturation.json
+++ b/fhirResourcesToLoad/o2billy_03__observation_oxygensaturation.json
@@ -1,25 +1,25 @@
 {
   "resourceType": "Observation",
-  "id": "obs015B",
+  "id": "obs015",
   "status": "final",
   "category": [
     {
       "coding": [
         {
-          "system": "http://hl7.org/fhir/observation-category",
-          "code": "laboratory",
-          "display": "laboratory"
+          "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+          "code": "vital-signs",
+          "display": "Vital Signs"
         }
       ],
-      "text": "Laboratory"
+      "text": "Vital Signs"
     }
   ],
   "code": {
     "coding": [
       {
         "system": "http://loinc.org",
-        "code": "31100-1",
-        "display": "Hematocrit [Volume Fraction] of Blood by Impedance"
+        "code": "59408-5",
+        "display": "Oxygen saturation in Arterial blood by Pulse oximetry"
       }
     ]
   },
@@ -28,7 +28,7 @@
   },
   "issued": "2020-03-20T15:30:10+01:00",
   "valueQuantity": {
-    "value": 69,
+    "value": 91,
     "unit": "%",
     "system": "http://unitsofmeasure.org",
     "code": "%"
@@ -38,26 +38,27 @@
       "coding": [
         {
           "system": "http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation",
-          "code": "H",
-          "display": "High"
+          "code": "N",
+          "display": "Normal"
         }
-      ]
+      ],
+      "text": "Normal (applies to non-numeric results)"
     }
   ],
   "referenceRange": [
     {
       "low": {
-        "value": 42,
+        "value": 90,
         "unit": "%",
         "system": "http://unitsofmeasure.org",
         "code": "%"
       },
       "high": {
-        "value": 54,
+        "value": 99,
         "unit": "%",
         "system": "http://unitsofmeasure.org",
         "code": "%"
       }
     }
   ]
-}
+} 

--- a/fhirResourcesToLoad/o2billy_04__device-request.json
+++ b/fhirResourcesToLoad/o2billy_04__device-request.json
@@ -34,5 +34,19 @@
   },
   "performer": {
     "reference": "Practitioner/pra1234"
+  },
+  "intent": "original-order",
+  "occurrenceTiming" : {
+    "repeat": {
+      "boundsDuration": {
+        "value": 8,
+        "unit": "mo",
+        "system": "http://unitsofmeasure.org",
+        "code": "mo"
+      }
+    },
+    "code": {
+      "text": "During sleep AND During exertion"
+    }
   }
 }

--- a/fhirResourcesToLoad/o2john_03__conditionD.json
+++ b/fhirResourcesToLoad/o2john_03__conditionD.json
@@ -1,0 +1,42 @@
+{
+  "resourceType": "Condition",
+  "id": "cond013d",
+  "clinicalStatus": {
+    "coding": [
+      {
+        "code": "active"
+      }
+    ]
+  },
+  "verificationStatus": {
+    "coding": [
+      {
+        "code": "confirmed"
+      }
+    ]
+  },
+  "category": [
+    {
+      "coding": [
+        {
+          "system": "http://hl7.org/fhir/condition-category",
+          "code": "encounter-diagnosis",
+          "display": "Encounter Diagnosis"
+        }
+      ]
+    }
+  ],
+  "code": {
+    "coding": [
+      {
+        "system": "http://snomed.info/sct",
+        "version": "2020-03",
+        "code": "195985008",
+        "display": "Post-infective bronchiectasis (disorder)"
+      }
+    ]
+  },
+  "subject": {
+    "reference": "Patient/pat013"
+  }
+}

--- a/fhirResourcesToLoad/o2teddy_03_observation_pao2.json
+++ b/fhirResourcesToLoad/o2teddy_03_observation_pao2.json
@@ -1,6 +1,6 @@
 {
     "resourceType": "Observation",
-    "id": "obs-pat015-pao2",
+    "id": "obs-pat014-pao2",
     "category": [
       {
         "coding": [
@@ -24,7 +24,7 @@
       ]
     },
     "subject": {
-      "reference": "Patient/pat015"
+      "reference": "Patient/pat014"
     },
     "issued": "2020-01-20T15:30:10+01:00",
     "valueQuantity": {
@@ -33,16 +33,18 @@
       "system": "http://unitsofmeasure.org",
       "code": "mm[Hg]"
     },
-    "interpretation": {
-      "coding": [
-        {
-          "system": "http://hl7.org/fhir/v2/0078",
-          "code": "L",
-          "display": "LOW"
-        }
-      ],
-      "text": "Normal (applies to non-numeric results)"
-    },
+    "interpretation": [
+      {
+        "coding": [
+          {
+            "system": "http://hl7.org/fhir/v2/0078",
+            "code": "L",
+            "display": "LOW"
+          }
+        ],
+        "text": "Normal (applies to non-numeric results)"
+      }
+    ],
     "referenceRange": [
       {
         "low": {


### PR DESCRIPTION
Migrate the data added to STU3 branch over to R4 so it may be used with corresponding changes to Home Oxygen Therapy.

Also cleared up an identifier mistake.