### PR TITLE
Support MedicationDispense for ImmunosuppressiveDrugs

### DIFF
--- a/fhirResourcesToLoad/o2teddy_medicationdispense.json
+++ b/fhirResourcesToLoad/o2teddy_medicationdispense.json
@@ -1,0 +1,79 @@
+{
+  "resourceType": "MedicationDispense",
+  "id": "pat014-meddispsense-azathioprine",
+  "medicationCodeableConcept": {
+    "coding": [
+      {
+        "system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+        "code": "105611",
+        "display": "azathioprine 50 MG Oral Tablet [Imuran]"
+      }
+    ]
+  },
+  "status": "active",
+  "intent": "order",
+  "subject": {
+    "reference": "Patient/pat014",
+    "display": "Theodor Roosevelt"
+  },
+  "whenHandedOver": "2020-11-11",
+  "performer": [
+    {
+      "actor": {
+        "reference": "Practitioner/pra1234"
+      }
+    }
+  ],
+  "quantity": {
+    "value": 30,
+    "system": "http://terminology.hl7.org/CodeSystem/v3-orderableDrugForm",
+    "code": "TAB"
+  },
+  "daysSupply": {
+    "value": 10,
+    "unit": "Day",
+    "system": "http://unitsofmeasure.org",
+    "code": "d"
+  },
+  "dosageInstruction": [
+    {
+      "sequence": 1,
+      "text": "50 mg PO daily for remission induction",
+      "timing": {
+        "repeat": {
+          "frequency": 1,
+          "period": 1,
+          "periodUnit": "d"
+        }
+      },
+      "route": {
+        "coding": [
+          {
+            "system": "http://snomed.info/sct",
+            "code": "26643006",
+            "display": "Oral route (qualifier value)"
+          }
+        ]
+      },
+      "doseAndRate": [
+        {
+          "type": {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/dose-rate-type",
+                "code": "ordered",
+                "display": "Ordered"
+              }
+            ]
+          },
+          "doseQuantity": {
+            "value": 50,
+            "unit": "mg",
+            "system": "http://unitsofmeasure.org",
+            "code": "mg"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/fhirResourcesToLoad/o2teddy_medicationdispense.json
+++ b/fhirResourcesToLoad/o2teddy_medicationdispense.json
@@ -25,12 +25,12 @@
     }
   ],
   "quantity": {
-    "value": 30,
+    "value": 90,
     "system": "http://terminology.hl7.org/CodeSystem/v3-orderableDrugForm",
     "code": "TAB"
   },
   "daysSupply": {
-    "value": 10,
+    "value": 90,
     "unit": "Day",
     "system": "http://unitsofmeasure.org",
     "code": "d"

--- a/fhirResourcesToLoad/o2teddy_medicationrequest.json
+++ b/fhirResourcesToLoad/o2teddy_medicationrequest.json
@@ -77,5 +77,13 @@
         }
       ]
     }
-  ]
+  ],
+  "dispenseRequest": {
+    "quantity": {
+      "value": 90,
+      "system": "http://terminology.hl7.org/CodeSystem/v3-orderableDrugForm",
+      "code": "TAB"
+    },
+    "numberOfRepeatsAllowed": 3
+  }
 }


### PR DESCRIPTION
This PR supports MedicationDispense for immunosuppressiveDrugs.

To test:
Need to switch to mdispense for every repo: CRD, DTR, test-ehr, CDS-Library, and crd-request-generator

From request generator, select patient pat014
Pick medication request 105611, go through the whole DRLS flow to see the order form as before
Pick medication dispense 105611, go through the whole DRLS flow to see the dispense form