### PR TITLE
modified ehr to use patient instead of patientId

### DIFF
--- a/src/main/java/org/hl7/davinci/ehrserver/authproxy/AuthProxy.java
+++ b/src/main/java/org/hl7/davinci/ehrserver/authproxy/AuthProxy.java
@@ -84,7 +84,7 @@ public class AuthProxy {
     try {
       ResponseEntity<TokenResponse> response = restTemplate.postForEntity(Config.get("oauth_token"), request, TokenResponse.class);
       Objects.requireNonNull(response.getBody())
-          .setPatientId(payload.getPatientId())
+          .setPatient(payload.getPatient())
           .setAppContext(payload.getAppContext());
       response = ResponseEntity.ok(response.getBody());
 

--- a/src/main/java/org/hl7/davinci/ehrserver/authproxy/Parameters.java
+++ b/src/main/java/org/hl7/davinci/ehrserver/authproxy/Parameters.java
@@ -1,7 +1,7 @@
 package org.hl7.davinci.ehrserver.authproxy;
 
 public class Parameters {
-  private String patientId;
+  private String patient;
   private String appContext;
 
 
@@ -9,20 +9,20 @@ public class Parameters {
     return appContext;
   }
 
-  public String getPatientId() {
-    return patientId;
+  public String getPatient() {
+    return patient;
   }
 
   public void setAppContext(String appContext) {
     this.appContext = appContext;
   }
 
-  public void setPatientId(String patientId) {
-    this.patientId = patientId;
+  public void setPatient(String patient) {
+    this.patient = patient;
   }
 
   @Override
   public String toString() {
-    return patientId + ", "  + appContext.toString();
+    return patient + ", "  + appContext.toString();
   }
 }

--- a/src/main/java/org/hl7/davinci/ehrserver/authproxy/Payload.java
+++ b/src/main/java/org/hl7/davinci/ehrserver/authproxy/Payload.java
@@ -29,8 +29,8 @@ public class Payload {
     return launchUrl;
   }
 
-  public String getPatientId() {
-    return parameters.getPatientId();
+  public String getPatient() {
+    return parameters.getPatient();
   }
 
 

--- a/src/main/java/org/hl7/davinci/ehrserver/authproxy/PayloadDAOImpl.java
+++ b/src/main/java/org/hl7/davinci/ehrserver/authproxy/PayloadDAOImpl.java
@@ -32,7 +32,7 @@ public class PayloadDAOImpl implements PayloadDAO {
     // create table
     Statement stmt = conn.createStatement();
     try {
-      jdbcTemplate.execute("Create table appcontext (launchId varchar(255) primary key, launchUrl varchar(212) NOT NULL, patientId varchar(128) NOT NULL, appContext varchar(8192), launchCode varchar(512), redirectUri varchar(512))");
+      jdbcTemplate.execute("Create table appcontext (launchId varchar(255) primary key, launchUrl varchar(212) NOT NULL, patient varchar(128) NOT NULL, appContext varchar(8192), launchCode varchar(512), redirectUri varchar(512))");
 
       logger.info("PayloadDAOImpl: AppContext table created in database");
 
@@ -46,8 +46,8 @@ public class PayloadDAOImpl implements PayloadDAO {
 
   @Override
   public void createPayload(Payload payload) {
-    String sql = "insert into appcontext (launchId, launchUrl, patientId, appContext) values (?, ?, ?, ?)";
-    jdbcTemplate.update(sql, payload.getLaunchId(), payload.getLaunchUrl(), payload.getPatientId(), payload.getAppContext());
+    String sql = "insert into appcontext (launchId, launchUrl, patient, appContext) values (?, ?, ?, ?)";
+    jdbcTemplate.update(sql, payload.getLaunchId(), payload.getLaunchUrl(), payload.getPatient(), payload.getAppContext());
     logger.info("Created payload: " + payload.toString());
   }
 

--- a/src/main/java/org/hl7/davinci/ehrserver/authproxy/PayloadMapper.java
+++ b/src/main/java/org/hl7/davinci/ehrserver/authproxy/PayloadMapper.java
@@ -15,7 +15,7 @@ public class PayloadMapper implements RowMapper<Payload> {
     payload.setLaunchUrl(rs.getString("launchUrl"));
     payload.setRedirectUri(rs.getString("redirectUri"));
     Parameters parameters = new Parameters();
-    parameters.setPatientId(rs.getString("patientId"));
+    parameters.setPatient(rs.getString("patient"));
     parameters.setAppContext(rs.getString("appContext"));
     payload.setParameters(parameters);
     return payload;

--- a/src/main/java/org/hl7/davinci/ehrserver/authproxy/TokenResponse.java
+++ b/src/main/java/org/hl7/davinci/ehrserver/authproxy/TokenResponse.java
@@ -6,7 +6,7 @@ public class TokenResponse {
   private int expires_in;
   private String scope;
   private String refresh_token;
-  private String patientId;
+  private String patient;
   private String appContext;
 
 
@@ -71,12 +71,12 @@ public class TokenResponse {
     return this;
   }
 
-  public String getPatientId() {
-    return patientId;
+  public String getPatient() {
+    return patient;
   }
 
-  public TokenResponse setPatientId(String patientId) {
-    this.patientId = patientId;
+  public TokenResponse setPatient(String patientId) {
+    this.patient = patientId;
     return this;
   }
 }


### PR DESCRIPTION
modifies the database and response token to use `patient` instead of `patientId`.  Spring auto-fills from the request body based on variable name.