### PR TITLE
handle standalone launch

### DIFF
--- a/src/main/java/org/hl7/davinci/ehrserver/authproxy/PayloadDAOImpl.java
+++ b/src/main/java/org/hl7/davinci/ehrserver/authproxy/PayloadDAOImpl.java
@@ -51,6 +51,12 @@ public class PayloadDAOImpl implements PayloadDAO {
     logger.info("Created payload: " + payload.toString());
   }
 
+  public void createStandalonePayload(Payload payload) {
+    String sql = "insert into appcontext (launchId, launchUrl, patient, appContext) values (?, ?, ?, ?)";
+    jdbcTemplate.update(sql, payload.getLaunchId(), "", "", "");
+    logger.info("Created payload: " + payload.toString());
+  }
+
   @Override
   public Payload getPayload(String launchId) {
     String sql = "select * from appcontext where launchId = ?";


### PR DESCRIPTION
This should allow the test-ehr to authenticate SMART apps launched in standalone mode.  There's another problem with DTR, which causes the standalone launch to fail.  Right now the DTR app doesn't know where to get the questionnaire for standalone launches after it gets the QuestionnaireResponse, so it fails.  But you can test that this works by getting through the authorization and making it to the DTR screen that let's you choose a QuestionnaireResponse.

