### PR TITLE
add auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,20 @@ To load the data from the json files in fhirResourcesToLoad, run the following s
 
 >Note: 'gradle loadData' can only be run while the FHIR server is running and `use_oauth` is false in         `src/main/resources/fhirServer.properties`
 
+## Using OAuth security features
+The FHIR server is open by default, but this can be changed in the `fhirServer.properties` file.  
+
+First, change the `use_oauth` flag to `true` to turn on security.  Then set the `client_id`, `client_secret`, and `oauth_token` fields.
+
+If using Keycloak and following the [CRD](https://github.com/HL7-DaVinci/CRD) guide, the `client_id` and `oauth_token` fields can be left as default.  The `client_secret` can be found with the following steps:
+
+1) Open the keycloak admin console (http://localhost:8180/auth) and log in
+2) Open the ClientFhirServer, then the `clients` tab, and click `app-token`.  
+3) Click on the `Credentials` tab, use the `regenerate secret` option if needed.
+4) Copy the client secret into the properties file under `client_secret`
+
+Finally, ensure that the [request generator](https://github.com/HL7-DaVinci/crd-request-generator) has the correct username and password in the `properties.json` file.  If following the CRD guide, this will be one of the users created when setting up Keycloak.
+
 ## Server endpoints
 |Relative URL|Endpoint Description|
 |----|----|

--- a/src/main/java/ca/uhn/fhir/jpa/starter/BaseJpaRestfulServer.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/BaseJpaRestfulServer.java
@@ -45,6 +45,7 @@ import ca.uhn.fhir.rest.server.util.ISearchParamRegistry;
 import ca.uhn.fhir.validation.IValidatorModule;
 import ca.uhn.fhir.validation.ResultSeverityEnum;
 import com.google.common.base.Strings;
+import org.hl7.davinci.ehrserver.ClientAuthorizationInterceptor;
 import org.hl7.davinci.ehrserver.ServerConformanceR4;
 import org.hl7.davinci.ehrserver.interceptor.OrderIdentifierAdditionInterceptor;
 import org.hl7.fhir.r4.model.Bundle.BundleType;
@@ -230,9 +231,13 @@ public class BaseJpaRestfulServer extends RestfulServer {
     loggingInterceptor.setLogExceptions(appProperties.getLogger().getLog_exceptions());
     this.registerInterceptor(loggingInterceptor);
 
+    ClientAuthorizationInterceptor clientAuthorizationInterceptor = new ClientAuthorizationInterceptor();
+    this.registerInterceptor(clientAuthorizationInterceptor);
+
+
     // import interceptor for adding order identifier
     this.registerInterceptor(new OrderIdentifierAdditionInterceptor());
-    
+
     /*
      * If you are hosting this server at a specific DNS name, the server will try to
      * figure out the FHIR base URL based on what the web container tells it, but

--- a/src/main/resources/fhirServer.properties
+++ b/src/main/resources/fhirServer.properties
@@ -1,7 +1,7 @@
 client_id = app-token
 client_secret= #replaceMe#
 realm=ClientFhirServer
-use_oauth = true
+use_oauth = false
 oauth_token = http://localhost:8180/auth/realms/ClientFhirServer/protocol/openid-connect/token
 oauth_authorize =  http://localhost:8180/auth/realms/ClientFhirServer/protocol/openid-connect/auth
 proxy_authorize = http://localhost:8080/test-ehr/auth

--- a/src/main/resources/fhirServer.properties
+++ b/src/main/resources/fhirServer.properties
@@ -1,7 +1,7 @@
 client_id = app-token
 client_secret= #replaceMe#
 realm=ClientFhirServer
-use_oauth = false
+use_oauth = true
 oauth_token = http://localhost:8180/auth/realms/ClientFhirServer/protocol/openid-connect/token
 oauth_authorize =  http://localhost:8180/auth/realms/ClientFhirServer/protocol/openid-connect/auth
 proxy_authorize = http://localhost:8080/test-ehr/auth


### PR DESCRIPTION
reinstates the auth interceptor and defaults the auth variable to "true".  Test this out and see if it causes unnecessary trouble while testing or developing.  If it's a burden, we can default it back to "false".