### PR TITLE
Changed Teddy's coverage to be Part B to test coverage CQL rules

### DIFF
--- a/fhirResourcesToLoad/o2teddy_02__coverage.json
+++ b/fhirResourcesToLoad/o2teddy_02__coverage.json
@@ -13,7 +13,7 @@
         "system": "http://hl7.org/fhir/coverage-class",
         "code": "plan"
       },
-      "value": "Medicare Part A"
+      "value": "Medicare Part B"
     }
   ],
   "payor": [


### PR DESCRIPTION
This test-ehr PR is used to change Teddy's coverage to be Medicare Part B for testing purposes of these three PRs for CQL Rules.

To test: William Oster has Medicare Part A and Teddy Roosevelt has Part B. The example CQL rule adds a condition to HomeOxygenTherapy'sRULE_APPLIES that the coverage must be Medicare Part A. Thus, for William Oster Home Oxygen Therapy should return the expected cards but for Teddy Roosevelt it should return "No Documentation Rules Found"

Use with branches:
- CRD: coverage-rules https://github.com/HL7-DaVinci/CRD/pull/278
- CDS-Library: coverage rules https://github.com/HL7-DaVinci/CDS-Library/pull/92